### PR TITLE
Switch from using 'requests' to 'aiohttp' to improve performance

### DIFF
--- a/custom_components/solar_sunsynk/manifest.json
+++ b/custom_components/solar_sunsynk/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/MorneSaunders360/Solar-Sunsynk",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/MorneSaunders360/Solar-Sunsynk/issues",
-  "requirements": ["requests"],
+  "requirements": ["tenacity>=9"],
   "version": "1.0.14"
 }


### PR DESCRIPTION
This PR improves performance by switching from the blocking `requests` library to the fully async `aiohttp` library.

Going fully asynchronous produces a ~4x improvement in latency when doing `get_all_data()` as can be seen from the following debug logs obtained from Home Assistant.

- Using requests:
  > 2025-03-15 18:11:30.186 DEBUG (MainThread) [custom_components.solar_sunsynk] Finished fetching solar_sunsynk data in **6.506 seconds** (success: True)`
- Using aiohttp:
  > 2025-03-15 17:26:52.214 DEBUG (MainThread) [custom_components.solar_sunsynk] Finished fetching solar_sunsynk data in **1.656 seconds** (success: True)`
 
Other improvements:

- Use `tenacity` for retry  logic. This has the benefit of adding exponential backoff to **all** API interactions (including authentication). Authentication failures due to incorrect credentials (username or password) will not be retried.
- Perform all API calls in `get_all_data()` asynchronously and concurrently.
- Reuse the session object between API calls to [align with best practice recommendations](https://docs.aiohttp.org/en/stable/client_quickstart.html#make-a-request). This also sets the session headers only once instead of on every request.
- Raise `HomeAssistantError` on permanent failures as per the [Home Assistant developer guide](https://developers.home-assistant.io/docs/core/platform/raising_exceptions/).
- Remove unused import `SunsynkApiNames`